### PR TITLE
fix(web): serve axios from jsdelivr (cdnjs is missing 1.12.x)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -180,7 +180,7 @@
     </div>
 
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/1.12.2/axios.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios@1.12.2/dist/axios.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/7.8.2/rxjs.umd.min.js"></script>
 
     <script>


### PR DESCRIPTION
cdnjs returns HTTP 404 with `content-type: text/html` for `axios@1.12.x`, even though their metadata API lists 1.12.2 as the current version. With `X-Content-Type-Options: nosniff`, the browser refuses to execute the response as JavaScript and the page falls over (all button POSTs fail because `axios` is undefined).

Swapping the URL to jsdelivr serves the exact same 1.12.2 file with `content-type: application/javascript`. Verified:

```
$ curl -sI https://cdn.jsdelivr.net/npm/axios@1.12.2/dist/axios.min.js
HTTP/2 200
content-type: application/javascript; charset=utf-8
content-length: 54937
cache-control: public, max-age=31536000, immutable
```

No behavior change \u2014 same version, same code.